### PR TITLE
Fix ValidationFailed error

### DIFF
--- a/resources/envdir.rb
+++ b/resources/envdir.rb
@@ -44,7 +44,7 @@ action :create do
       owner new_resource.owner
       group new_resource.group
       action :create
-      content v[:value]
+      content v[:value].to_s
       mode v[:sensitive] ? '0o600' : '0o644'
     end
   end

--- a/test/cookbooks/envdir_ii_test/recipes/default.rb
+++ b/test/cookbooks/envdir_ii_test/recipes/default.rb
@@ -34,6 +34,12 @@ envdir_ii_envdir '/env/default' do
     'SSS' => {
       value: 'sss',
       sensitive: true,
+    },
+    'INT' => {
+      value: 1,
+    },
+    'BOOL' => {
+      value: true,
     }
   )
 end

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -21,6 +21,22 @@ describe file('/env/default/SSS') do
   its('mode') { should eq 0o600 }
 end
 
+describe file('/env/default/INT') do
+  it { should exist }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('content') { should eq '1' }
+  its('mode') { should eq 0o644 }
+end
+
+describe file('/env/default/BOOL') do
+  it { should exist }
+  its('owner') { should eq 'root' }
+  its('group') { should eq 'root' }
+  its('content') { should eq 'true' }
+  its('mode') { should eq 0o644 }
+end
+
 describe file('/env/default/DDD') do
   it { should_not exist }
 end


### PR DESCRIPTION
### Code
```ruby
envdir_ii_envdir '/env/default' do
  values(
    'INT' => {
      value: 1,
    },
    'BOOL' => {
      value: true,
    },
  )
end
```

### Expected behavior

The string value will be output to files.

### Actual behavior

Raise `Chef::Exceptions::ValidationFailed` error.
```
FATAL: Stacktrace dumped to /opt/kitchen/cache/chef-stacktrace.out
FATAL: ---------------------------------------------------------------------------------------
FATAL: PLEASE PROVIDE THE CONTENTS OF THE stacktrace.out FILE (above) IF YOU FILE A BUG REPORT
FATAL: ---------------------------------------------------------------------------------------
FATAL: Chef::Exceptions::ValidationFailed: envdir_ii_envdir[/env/default] (envdir_ii_test::default line 29) had an error: Chef::Exceptions::ValidationFailed: Property content must be one of: String, nil!  You passed 1.
```